### PR TITLE
Change the default value of 'clean_filename'

### DIFF
--- a/videoclip.lua
+++ b/videoclip.lua
@@ -44,7 +44,7 @@ local config = {
     audio_format = 'opus', -- aac, opus
     audio_bitrate = '32k', -- 32k, 64k, 128k, 256k. aac requires higher bitrates.
     font_size = 24,
-    clean_filename = true,
+    clean_filename = 'yes',
 }
 
 mpopt.read_options(config, 'videoclip')


### PR DESCRIPTION
The `clean_filename` option can only take `yes` or `no` values. The default value of the option is `true`, which causes the following error: 

> [videoclip] Error: Can't convert 'true' to boolean!
> [videoclip] script-opts/videoclip.conf:11 error converting value 'true' for key 'clean_filename'

This PR fixes that.