### PR TITLE
Comment out duplicate `video_fps` field in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ video_quality=23
 preset=faster
 # FPS / framerate. Set to "auto" or a number.
 video_fps=auto
-video_fps=60
+#video_fps=60
 
 # Audio settings
 # Available formats: opus or aac


### PR DESCRIPTION
The default config in the README contains the lines

```
# FPS / framerate. Set to "auto" or a number.
video_fps=auto
video_fps=60
```

I assume one of these was meant to be commented out.