### PR TITLE
feat: respect XDG user directories

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -104,4 +104,17 @@ this.quote_if_necessary = function(args)
     return ret
 end
 
+this.query_xdg_user_dir = function(name)
+    local r = this.subprocess({ "xdg-user-dir", name })
+    if r.status == 0 then
+        return this.strip(r.stdout)
+    end
+    return nil
+end
+
+this.query_user_home_dir = function()
+    --- "USERPROFILE" is used on ReactOS and other Windows-like systems.
+    return os.getenv("HOME") or os.getenv("USERPROFILE")
+end
+
 return this

--- a/platform.lua
+++ b/platform.lua
@@ -10,6 +10,17 @@ local mp = require('mp')
 local utils = require('mp.utils')
 local this = {}
 
+local function get_fallback_video_dir()
+    return utils.join_path(
+            h.query_user_home_dir(),
+            (this.platform == this.Platform.macos and "Movies" or "Videos")
+    )
+end
+
+local function get_fallback_music_dir()
+    return utils.join_path(h.query_user_home_dir(), "Music")
+end
+
 this.Platform = {
     gnu_linux = "gnu_linux",
     macos = "macos",
@@ -20,14 +31,8 @@ this.platform = (
                 or h.is_mac() and this.Platform.macos
                 or this.Platform.gnu_linux
 )
-this.default_video_folder = h.strip(h.subprocess({"xdg-user-dir","VIDEOS"}).stdout) or utils.join_path(
-        (os.getenv("HOME") or os.getenv("USERPROFILE")),
-        (this.platform == this.Platform.macos and "Movies" or "Videos")
-)
-this.default_audio_folder = h.strip(h.subprocess({"xdg-user-dir","DESKTOP"}).stdout) or utils.join_path(
-        (os.getenv("HOME") or os.getenv('USERPROFILE')),
-        "Music"
-)
+this.default_video_folder = h.query_xdg_user_dir("VIDEOS") or get_fallback_video_dir()
+this.default_audio_folder = h.query_xdg_user_dir("MUSIC") or get_fallback_music_dir()
 this.curl_exe = (this.platform == this.Platform.windows and 'curl.exe' or 'curl')
 this.open_utility = (
         this.platform == this.Platform.windows and 'explorer.exe'

--- a/platform.lua
+++ b/platform.lua
@@ -20,11 +20,11 @@ this.platform = (
                 or h.is_mac() and this.Platform.macos
                 or this.Platform.gnu_linux
 )
-this.default_video_folder = h.subprocess({"xdg-user-dir","VIDEOS"}).stdout:gsub("\n$","") or utils.join_path(
+this.default_video_folder = h.strip(h.subprocess({"xdg-user-dir","VIDEOS"}).stdout) or utils.join_path(
         (os.getenv("HOME") or os.getenv("USERPROFILE")),
         (this.platform == this.Platform.macos and "Movies" or "Videos")
 )
-this.default_audio_folder = h.subprocess({"xdg-user-dir","DESKTOP"}).stdout:gsub("\n$","") or utils.join_path(
+this.default_audio_folder = h.strip(h.subprocess({"xdg-user-dir","DESKTOP"}).stdout) or utils.join_path(
         (os.getenv("HOME") or os.getenv('USERPROFILE')),
         "Music"
 )

--- a/platform.lua
+++ b/platform.lua
@@ -20,11 +20,11 @@ this.platform = (
                 or h.is_mac() and this.Platform.macos
                 or this.Platform.gnu_linux
 )
-this.default_video_folder = io.popen("xdg-user-dir VIDEOS"):read("*l") or utils.join_path(
+this.default_video_folder = h.subprocess({"xdg-user-dir","VIDEOS"}).stdout:match("%S*") or utils.join_path(
         (os.getenv("HOME") or os.getenv("USERPROFILE")),
         (this.platform == this.Platform.macos and "Movies" or "Videos")
 )
-this.default_audio_folder = io.popen("xdg-user-dir MUSIC"):read("*l") or utils.join_path(
+this.default_audio_folder = h.subprocess({"xdg-user-dir","MUSIC"}).stdout:match("%S*") or utils.join_path(
         (os.getenv("HOME") or os.getenv('USERPROFILE')),
         "Music"
 )

--- a/platform.lua
+++ b/platform.lua
@@ -20,11 +20,11 @@ this.platform = (
                 or h.is_mac() and this.Platform.macos
                 or this.Platform.gnu_linux
 )
-this.default_video_folder = utils.join_path(
+this.default_video_folder = io.popen("xdg-user-dir VIDEOS"):read("*l") or utils.join_path(
         (os.getenv("HOME") or os.getenv("USERPROFILE")),
         (this.platform == this.Platform.macos and "Movies" or "Videos")
 )
-this.default_audio_folder = utils.join_path(
+this.default_audio_folder = io.popen("xdg-user-dir MUSIC"):read("*l") or utils.join_path(
         (os.getenv("HOME") or os.getenv('USERPROFILE')),
         "Music"
 )

--- a/platform.lua
+++ b/platform.lua
@@ -20,11 +20,11 @@ this.platform = (
                 or h.is_mac() and this.Platform.macos
                 or this.Platform.gnu_linux
 )
-this.default_video_folder = h.subprocess({"xdg-user-dir","VIDEOS"}).stdout:match("%S*") or utils.join_path(
+this.default_video_folder = h.subprocess({"xdg-user-dir","VIDEOS"}).stdout:gsub("\n$","") or utils.join_path(
         (os.getenv("HOME") or os.getenv("USERPROFILE")),
         (this.platform == this.Platform.macos and "Movies" or "Videos")
 )
-this.default_audio_folder = h.subprocess({"xdg-user-dir","MUSIC"}).stdout:match("%S*") or utils.join_path(
+this.default_audio_folder = h.subprocess({"xdg-user-dir","DESKTOP"}).stdout:gsub("\n$","") or utils.join_path(
         (os.getenv("HOME") or os.getenv('USERPROFILE')),
         "Music"
 )


### PR DESCRIPTION
Previously, on gnu/linux, the videos directory was determined by combining $HOME with "VIDEOS", resulting in `$HOME/Videos` However, since user directories can be customized using `xdg-user-dir` (which is supported by almost all DE), hardcoding `$HOME/Videos` is not ideal.

You can query user dirs by running `xdg-user-dir DIRNAME`. The one we're interested in are `VIDEOS` and `MUSIC`. If the command fails (either the user don't have it installed if they're using something like a WM, or the user is not on gnu/linux) it will fallback to the previous implementation.

For more information about `xdg-user-dir`, refer to the arch wiki: https://wiki.archlinux.org/title/XDG_user_directories