### PR TITLE
feat: expand video and audio path from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Example configuration file:
 
 ```
 # Absolute paths to the folders where generated clips will be placed.
+# `~` are supported but variables (e.g. `$HOME`) are not supported due to mpv limitations.
 video_folder_path=~/Videos
 audio_folder_path=~/Music
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ Example configuration file:
 
 ```
 # Absolute paths to the folders where generated clips will be placed.
-# `~` or `$HOME` are not supported due to mpv limitations.
-video_folder_path=/home/user/Videos
-audio_folder_path=/home/user/Music
+video_folder_path=~/Videos
+audio_folder_path=~/Music
 
 # Menu size
 font_size=24

--- a/encoder.lua
+++ b/encoder.lua
@@ -57,7 +57,7 @@ function this.append_embed_subs_args(args)
 end
 
 this.mk_out_path_video = function(clip_filename_noext)
-    return utils.join_path(this.config.video_folder_path, clip_filename_noext .. this.config.video_extension)
+    return utils.join_path(h.expand_path(this.config.video_folder_path), clip_filename_noext .. this.config.video_extension)
 end
 
 this.mkargs_video = function(out_clip_path)
@@ -108,7 +108,7 @@ this.mkargs_video = function(out_clip_path)
 end
 
 this.mk_out_path_audio = function(clip_filename_noext)
-    return utils.join_path(this.config.audio_folder_path, clip_filename_noext .. this.config.audio_extension)
+    return utils.join_path(h.expand_path(this.config.audio_folder_path), clip_filename_noext .. this.config.audio_extension)
 end
 
 this.mkargs_audio = function(out_clip_path)

--- a/helpers.lua
+++ b/helpers.lua
@@ -71,6 +71,10 @@ this.strip = function(str)
     return str:gsub("^%s*(.-)%s*$", "%1")
 end
 
+this.expand_path = function (str)
+    return mp.command_native({"expand-path", str})
+end
+
 this.human_readable_time = function(seconds)
     if type(seconds) ~= 'number' or seconds < 0 then
         return 'empty'


### PR DESCRIPTION
Using `expand-path` input commands will allow you to expand path such as `~` where was not possible before.

This is important to have if you want to make your config to work across different users.

Also updated the example config on README to be `~/Videos` (which is the default)