### PR TITLE
feat: add `title` and date option for `filename_template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ litterbox=yes
 litterbox_expire=72h
 
 # Filename format
-# Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
+# Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
+#                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),
+#                 %P = am/pm %N = minutes, %S = seconds
 # Title will fallback to filename if it's not present
 #filename_template=%n_%s-%e(%d)
 filename_template=%n_%s-%e

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ litterbox=yes
 litterbox_expire=72h
 
 # Filename format
-# Available tags: %n = name, %s = start, %e = end, %d = duration
+# Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
+# Title will fallback to filename if it's not present
 #filename_template=%n_%s-%e(%d)
 filename_template=%n_%s-%e
 ```

--- a/encoder.lua
+++ b/encoder.lua
@@ -29,6 +29,7 @@ end
 local function construct_output_filename_noext()
     local filename = mp.get_property("filename") -- filename without path
     local title = mp.get_property("media-title") -- if the video doesn't have a title, it will fallback to filename
+    local date = os.date("*t") -- get current date and time as table
 
     -- Apply the same operation when the video doesn't have a title
     -- thus it will be the same as filename
@@ -39,13 +40,23 @@ local function construct_output_filename_noext()
         filename = clean_filename(filename)
     end
 
-    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
+    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
+    --                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),
+    --                 %P = am/pm %N = minutes, %S = seconds
     filename = this.config.filename_template
-                   :gsub("%%n", filename)
-                   :gsub("%%t", title)
-                   :gsub("%%s", h.human_readable_time(this.timings['start']))
-                   :gsub("%%e", h.human_readable_time(this.timings['end']))
-                   :gsub("%%d", h.human_readable_time(this.timings['end'] - this.timings['start']))
+            :gsub("%%n", filename)
+            :gsub("%%t", title)
+            :gsub("%%s", h.human_readable_time(this.timings['start']))
+            :gsub("%%e", h.human_readable_time(this.timings['end']))
+            :gsub("%%d", h.human_readable_time(this.timings['end'] - this.timings['start']))
+            :gsub("%%Y", date.year)
+            :gsub("%%M", h.two_digit(date.month))
+            :gsub("%%D", h.two_digit(date.day))
+            :gsub("%%H", h.two_digit(date.hour))
+            :gsub("%%I", h.two_digit(h.twelve_hour(date.hour)['hour']))
+            :gsub("%%P", h.twelve_hour(date.hour)['sign'])
+            :gsub("%%N", h.two_digit(date.min))
+            :gsub("%%S", h.two_digit(date.sec))
 
     return filename
 end

--- a/encoder.lua
+++ b/encoder.lua
@@ -17,6 +17,7 @@ end
 
 local function construct_output_filename_noext()
     local filename = mp.get_property("filename") -- filename without path
+    local title = mp.get_property("media-title") -- if the video doesn't have a title, it will fallback to filename
 
     filename = h.remove_extension(filename)
 
@@ -27,9 +28,16 @@ local function construct_output_filename_noext()
         filename = h.strip(filename)
     end
 
-    -- Available tags: %n = name, %s = start, %e = end, %d = duration
+    -- Apply the same operation when the video doesn't have a title
+    -- thus it will be the same as filename
+    if title == mp.get_property("filename") then
+      title = filename
+    end
+
+    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
     filename = this.config.filename_template
             :gsub("%%n", filename)
+            :gsub("%%t", title)
             :gsub("%%s", h.human_readable_time(this.timings['start']))
             :gsub("%%e", h.human_readable_time(this.timings['end']))
             :gsub("%%d", h.human_readable_time(this.timings['end'] - this.timings['start']))

--- a/encoder.lua
+++ b/encoder.lua
@@ -15,32 +15,37 @@ local function toms(timestamp)
     return string.format("%.3f", timestamp)
 end
 
-local function construct_output_filename_noext()
-    local filename = mp.get_property("filename") -- filename without path
-    local title = mp.get_property("media-title") -- if the video doesn't have a title, it will fallback to filename
-
+local function clean_filename(filename)
     filename = h.remove_extension(filename)
-
     if this.config.clean_filename then
         filename = h.remove_text_in_brackets(filename)
         filename = h.remove_special_characters(filename)
         -- remove_text_in_brackets might leave spaces at the start or the end, so trim those
         filename = h.strip(filename)
     end
+    return filename
+end
+
+local function construct_output_filename_noext()
+    local filename = mp.get_property("filename") -- filename without path
+    local title = mp.get_property("media-title") -- if the video doesn't have a title, it will fallback to filename
 
     -- Apply the same operation when the video doesn't have a title
     -- thus it will be the same as filename
-    if title == mp.get_property("filename") then
-      title = filename
+    if title == filename then
+        filename = clean_filename(filename)
+        title = filename
+    else
+        filename = clean_filename(filename)
     end
 
     -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
     filename = this.config.filename_template
-            :gsub("%%n", filename)
-            :gsub("%%t", title)
-            :gsub("%%s", h.human_readable_time(this.timings['start']))
-            :gsub("%%e", h.human_readable_time(this.timings['end']))
-            :gsub("%%d", h.human_readable_time(this.timings['end'] - this.timings['start']))
+                   :gsub("%%n", filename)
+                   :gsub("%%t", title)
+                   :gsub("%%s", h.human_readable_time(this.timings['start']))
+                   :gsub("%%e", h.human_readable_time(this.timings['end']))
+                   :gsub("%%d", h.human_readable_time(this.timings['end'] - this.timings['start']))
 
     return filename
 end
@@ -166,7 +171,7 @@ this.create_clip = function(clip_type, on_complete)
         end
     end)()
 
-    print("The following args will be executed:", table.concat(h.quote_if_necessary(args), " ") )
+    print("The following args will be executed:", table.concat(h.quote_if_necessary(args), " "))
 
     local output_dir_path = utils.split_path(output_file_path)
     local location_info = utils.file_info(output_dir_path)

--- a/helpers.lua
+++ b/helpers.lua
@@ -71,6 +71,23 @@ this.strip = function(str)
     return str:gsub("^%s*(.-)%s*$", "%1")
 end
 
+this.two_digit = function(num)
+    return string.format("%02d", num)
+end
+
+this.twelve_hour = function(num)
+  local sign = "pm"
+  local hour = num
+
+  if num > 12 then
+      hour = hour - 12
+  else
+      sign = "am"
+  end
+
+  return { sign = sign, hour = hour }
+end
+
 this.human_readable_time = function(seconds)
     if type(seconds) ~= 'number' or seconds < 0 then
         return 'empty'

--- a/videoclip.lua
+++ b/videoclip.lua
@@ -61,7 +61,9 @@ local config = {
     litterbox_expire = '72h', -- 1h, 12h, 24h, 72h
     sub_font = 'Noto Sans CJK JP',
     -- Filename format
-    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
+    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
+    --                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),
+    --                 %P = am/pm %N = minutes, %S = seconds
     filename_template='%n_%s-%e',
 }
 

--- a/videoclip.lua
+++ b/videoclip.lua
@@ -61,7 +61,7 @@ local config = {
     litterbox_expire = '72h', -- 1h, 12h, 24h, 72h
     sub_font = 'Noto Sans CJK JP',
     -- Filename format
-    -- Available tags: %n = name, %s = start, %e = end, %d = duration
+    -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration
     filename_template='%n_%s-%e',
 }
 


### PR DESCRIPTION
This option will return `media-title` of the file. If it's not present however, it will fallback into `filename` and will apply the same operation as `filename` (remove extension).

Why? Well if we're playing a video from http, `media-title` will be more useful than `filename`. For example, when we play a youtube video, the `filename` is `watch?v={video_id}` and the `media-title` would be the actual title of the video.

---

Also do we need to also add date? e.g. to make it the same as OBS default recordings
```
YYYY-MM-DD HH-MM-SS
```
And the nice thing about having date in the filename is that it's easier to sort. (and the filename would be consistent too!). I'd like to work on it.