### PR TITLE
feat: add an option to disable "help message"

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ litterbox=yes
 # Available values: 1h, 12h, 24h, 72h
 litterbox_expire=72h
 
+# Enable help messages on console
+help_msg=yes
+
 # Filename format
 # Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
 #                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),

--- a/videoclip.lua
+++ b/videoclip.lua
@@ -60,7 +60,7 @@ local config = {
     -- Determines expire time of files uploaded to litterbox
     litterbox_expire = '72h', -- 1h, 12h, 24h, 72h
     sub_font = 'Noto Sans CJK JP',
-    enable_welcome = true,
+    help_msg = true,
     -- Filename format
     -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
     --                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),

--- a/videoclip.lua
+++ b/videoclip.lua
@@ -60,6 +60,7 @@ local config = {
     -- Determines expire time of files uploaded to litterbox
     litterbox_expire = '72h', -- 1h, 12h, 24h, 72h
     sub_font = 'Noto Sans CJK JP',
+    enable_welcome = true,
     -- Filename format
     -- Available tags: %n = filename, %t = title, %s = start, %e = end, %d = duration,
     --                 %Y = year, %M = months, %D = day, %H = hours (24), %I = hours (12),
@@ -473,4 +474,4 @@ end
 validate_config()
 encoder.init(config, main_menu.timings)
 mp.add_key_binding('c', 'videoclip-menu-open', main_menu.open)
-mp.msg.warn("Press 'c' to open the videoclip menu.")
+if config.enable_welcome then mp.msg.warn("Press 'c' to open the videoclip menu.") end


### PR DESCRIPTION
The message I meant is the "Press 'c' to open the videoclip menu" that uses warning(?) to print a help message to the console. I'm not against it but I think there should be an option to turn it off.